### PR TITLE
Specify working omniauth versions

### DIFF
--- a/lib/omniauth/strategies/mavenlink.rb
+++ b/lib/omniauth/strategies/mavenlink.rb
@@ -3,7 +3,6 @@ require 'omniauth-oauth2'
 module OmniAuth
   module Strategies
   	class Mavenlink < OmniAuth::Strategies::OAuth2
-  		
       option :name, 'mavenlink'
 
       option :client_options, {
@@ -41,8 +40,6 @@ module OmniAuth
       def parsed_info
         @parsed_info = raw_info['users'].values.first
       end
-
   	end
   end
 end
-

--- a/omniauth-mavenlink.gemspec
+++ b/omniauth-mavenlink.gemspec
@@ -15,8 +15,8 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = OmniAuth::Mavenlink::VERSION
 
-  gem.add_dependency 'omniauth', '~> 1.0'
-  gem.add_dependency 'omniauth-oauth2', '~> 1.1'
+  gem.add_dependency 'omniauth', '~> 1.1.0'
+  gem.add_dependency 'omniauth-oauth2', '~> 1.1.0'
   gem.add_development_dependency 'rspec', '~> 2.7'
   gem.add_development_dependency 'rack-test'
   gem.add_development_dependency 'simplecov'


### PR DESCRIPTION
This bumps `omniauth` to `1.1`. It also specifies the patch versions for both `omniauth` and `omniauth-oauth2`. Oddly this only enforces the minor version... ie: `omniauth 1.1.0` when bundled gets you `omniauth 1.1.4`. Maybe this is intended behavior and I just don't understand gem dependencies here? 

Either way this prevents bundler from installing `omniauth-oauth2` versions that do not work. These are the latest versions that work under my testing.
