### PR TITLE
Bump for Rails 5.0

### DIFF
--- a/omniauth-mavenlink.gemspec
+++ b/omniauth-mavenlink.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.version       = OmniAuth::Mavenlink::VERSION
 
   gem.add_dependency 'omniauth', '~> 1.3.1'
-  gem.add_dependency 'omniauth-oauth2', '~> 1.1.0'
+  gem.add_dependency 'omniauth-oauth2', '~> 1.3.1'
   gem.add_development_dependency 'rspec', '~> 2.7'
   gem.add_development_dependency 'rack-test'
   gem.add_development_dependency 'simplecov'

--- a/omniauth-mavenlink.gemspec
+++ b/omniauth-mavenlink.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = OmniAuth::Mavenlink::VERSION
 
-  gem.add_dependency 'omniauth', '~> 1.2.0'
+  gem.add_dependency 'omniauth', '~> 1.3.1'
   gem.add_dependency 'omniauth-oauth2', '~> 1.1.0'
   gem.add_development_dependency 'rspec', '~> 2.7'
   gem.add_development_dependency 'rack-test'


### PR DESCRIPTION
This PR bumps dependencies to get a successful bundle in Konekti. We should do some due diligence to make sure that this makes sense.

In particular, it would be nice to instead have a more permissive version set. More information about declaring gem dependencies can be found here:

https://guides.rubygems.org/patterns/#declaring-dependencies