### PR TITLE
Bump omniauth and omniauth-oauth2 dependency versions

### DIFF
--- a/omniauth-mavenlink.gemspec
+++ b/omniauth-mavenlink.gemspec
@@ -15,8 +15,8 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = OmniAuth::Mavenlink::VERSION
 
-  gem.add_dependency 'omniauth', '~> 1.2.0'
-  gem.add_dependency 'omniauth-oauth2', '~> 1.1.0'
+  gem.add_dependency 'omniauth', '~> 1.6.0'
+  gem.add_dependency 'omniauth-oauth2', '~> 1.3.1'
   gem.add_development_dependency 'rspec', '~> 2.7'
   gem.add_development_dependency 'rack-test'
   gem.add_development_dependency 'simplecov'


### PR DESCRIPTION
This PR updates the `omniauth-oauth2` dependency to 1.3.1 to allow using a later version (>0.10) of `faraday` in konekti. We need to bump `faraday` in konekti to use the `qualtrics_api` gem.

It also bumps the `omniauth` version to 1.6.0 to silence a warning introduced after updating `faraday` (more info: https://github.com/omniauth/omniauth/issues/872).

I tested creating all oauth services after the dependency bumps and everything is working as expected.